### PR TITLE
Fix "Automatic DNS" link in the getting-started doc

### DIFF
--- a/docs/getting-started/installing-magiclamp.md
+++ b/docs/getting-started/installing-magiclamp.md
@@ -41,7 +41,7 @@ docker-compose up -d
 
 ### Step 4 (optional)
 
-To take full advantage of magicLAMP, you may want to use [Automatic DNS](/automatic-dns)
+To take full advantage of magicLAMP, you may want to use [Automatic DNS](https://magiclamp.app/en/stable/automatic-dns)
 and [Automatic SSL](https://magiclamp.app/en/stable/automatic-ssl).
 
 See their respective documentation for information on how to set them up.


### PR DESCRIPTION
**Describe your change**
There is a broken link for the `Automatic DNS` link inside the Getting Started section.

**Motivation and Context**
Fix the link.

**Type of Change**
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

**Checklist**
Go over all the following points, and put an `x` in all the boxes that apply
- [x] I've read the [Contribution Guide](https://github.com/chrisnharvey/magicLAMP/blob/master/CONTRIBUTING.md).
- [x] I've updated the **documentation**.
- [x] I've targeted the correct branch with this Pull Request.
