### PR TITLE
Use imagick extension from pecl

### DIFF
--- a/containers/php80/Dockerfile
+++ b/containers/php80/Dockerfile
@@ -8,24 +8,10 @@ RUN apt-get update && \
     docker-php-ext-configure gd --with-webp --with-jpeg && \
     docker-php-ext-install -j$(nproc) gd && \
     docker-php-ext-install mysqli pdo pdo_mysql pdo_pgsql zip bcmath && \
-    # Imagick does not support PHP 8 yet
-    # pecl install imagick && \
+    pecl install imagick && \
     pecl install swoole && \
     pecl install memcached && \
-    # Imagick does not support PHP 8 yet
-    # docker-php-ext-enable imagick opcache sodium swoole memcached
-    docker-php-ext-enable opcache sodium swoole memcached
-
-# Temporary build of imagick from master branch
-RUN docker-php-source extract && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -qq git && \
-    git clone https://github.com/Imagick/imagick && \
-    cd imagick && \
-    phpize && \
-    ./configure && \
-    make install && \
-    docker-php-source delete && \
-    docker-php-ext-enable imagick
+    docker-php-ext-enable imagick opcache sodium swoole memcached
 
 ADD ./config/php.ini /usr/local/etc/php/conf.d/php.ini
 ADD ./config/php-fpm.conf /usr/local/etc/php-fpm.d/zzz-magicLAMP.conf


### PR DESCRIPTION
**Describe your change**
Imagick now has a stable release on PECL that supports PHP 8.0.

**Motivation and Context**
Removes the need to build imagick from the master branch in the PHP 8 container

**Type of Change**
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

**Checklist**
Go over all the following points, and put an `x` in all the boxes that apply
- [x] I've read the [Contribution Guide](https://github.com/chrisnharvey/magicLAMP/blob/master/CONTRIBUTING.md).
- [x] I've updated the **documentation**.
- [x] I've targeted the correct branch with this Pull Request.
